### PR TITLE
Promote HSLa. Trim the command menu.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -4,14 +4,6 @@
 		"command": "rgb_to_hsl",
 		"args":
 		{
-			"convert_all" : true
-		}
-	},
-	{
-		"keys": ["shift+ctrl+alt+u"],
-		"command": "rgb_to_hsl",
-		"args":
-		{
 			"convert_all" : true,
 			"force_alpha" : true
 		}

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,14 +4,6 @@
 		"command": "rgb_to_hsl",
 		"args":
 		{
-			"convert_all" : true
-		}
-	},
-	{
-		"keys": ["shift+ctrl+alt+u"],
-		"command": "rgb_to_hsl",
-		"args":
-		{
 			"convert_all" : true,
 			"force_alpha" : true
 		}

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,14 +4,6 @@
 		"command": "rgb_to_hsl",
 		"args":
 		{
-			"convert_all" : true
-		}
-	},
-	{
-		"keys": ["shift+ctrl+alt+u"],
-		"command": "rgb_to_hsl",
-		"args":
-		{
 			"convert_all" : true,
 			"force_alpha" : true
 		}

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,13 +1,5 @@
 [
   {
-    "caption": "HSL: Convert All RGB to HSL",
-    "command": "rgb_to_hsl",
-    "args":
-    {
-      "convert_all" : true
-    }
-  },
-  {
     "caption": "HSL: Convert All RGB to HSLA",
     "command": "rgb_to_hsl",
     "args":
@@ -15,10 +7,6 @@
       "convert_all" : true,
       "force_alpha" : true
     }
-  },
-  {
-    "caption": "HSL: Convert Selected RGB to HSL",
-    "command": "rgb_to_hsl"
   },
   {
     "caption": "HSL: Convert Selected RGB to HSLA",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -13,14 +13,6 @@
         "children":
         [
           {
-            "caption": "Convert All RGB to HSL",
-            "command": "rgb_to_hsl",
-            "args":
-            {
-              "convert_all" : true
-            }
-          },
-          {
             "caption": "Convert All RGB to HSLA",
             "command": "rgb_to_hsl",
             "args":
@@ -28,10 +20,6 @@
               "convert_all" : true,
               "force_alpha" : true
             }
-          },
-          {
-            "caption": "Convert Selected RGB to HSL",
-            "command": "rgb_to_hsl"
           },
           {
             "caption": "Convert Selected RGB to HSLA",

--- a/readme.md
+++ b/readme.md
@@ -10,15 +10,14 @@ In the past, due to browser (IE) compatibility, it was best to use a CSS preproc
 # Installation
 You can install using [Package Control](http://wbond.net/sublime_packages/package_control) or you can download or clone the repository and drop it into your Sublime Text packages directory.
 
-# Version 2 Features
+# Version 2.1 Features
+* Now converts everything to HSLA. HSL commands removed.
 * Version 2 now converts hex and RGB to HSL and RGBA to HSLA. The previous version only converted hex to HSL.
-* Optionally, you can convert hex, RGB, and RGBA to HSLA (force alpha). 
+* Optionally, you can convert hex, RGB, and RGBA to HSLA (force alpha).
 * You can now convert all hex, RGB, and RGBA colors in a file with a single command (`shift+ctrl+U`).
 
 # Usage
-* Convert All to HSL (preserving alpha): `shift+ctrl+U`
-* Convert All to HSLA (force alpha): `shift+ctrl+alt+U`
-* Convert Selected to HSL: `Edit > RGB to HSL`
+* Convert All to HSLA (force alpha): `shift+ctrl+U`
 * Convert Selected to HSLA: `Edit > RGB to HSL`
 
 # Why No Hex/HSL to RGB support


### PR DESCRIPTION
Great package, but too many unneeded options clutter the Sublime menu. Tony, I think it's okay to be 'opinionated' with this package and promote best practices. HSLa is the only way to go. No reason for anyone to be using Hex, RGB, or plain HSL.

...I don't think it would be opinionated actually, because it's such a no brainer. HSLa is 'the way'.

Hope you agree.